### PR TITLE
Bundler precompile local path

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ task :precompile do
   config = Capistrano::BundleRsync::Config
   run_locally do
     Bundler.with_clean_env do
-      within config.release_path do
+      within config.local_release_path do
         execute :bundle, 'install' # install development gems
         execute :bundle, 'exec rake assets:precompile'
       end


### PR DESCRIPTION
Maybe I'm wrong, but in the documentation, there is this exemple to precompile rails assets before rsyncing.
But the exemple use the server `release_path` and not the `local_release_path`.
An error will occur if the server release path is use because the folder doesn't exist

Using the `local_release_path`, bundler will precompile in the `.local_repo` release folder
